### PR TITLE
Enh1826

### DIFF
--- a/services/queue/dequeuer.go
+++ b/services/queue/dequeuer.go
@@ -1,0 +1,68 @@
+package queue
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	utils "github.com/b-eee/amagi"
+)
+
+const (
+	// DequeuerSleepDurationEnv the env var name of the sleep duration
+	DequeuerSleepDurationEnv = "QUEUE_DEQUEUER_INTERVAL_MS"
+
+	defaultSleepDuration     = (1 * time.Second)
+	defaultMaxConcurrentExec = 1
+)
+
+// Dequeue loop process for dequeuing the queue
+func Dequeue(itemPtr Executor) {
+	sleepDuration := getSleepDuration()
+	queueItem := Queue{}
+	queueItem.ItemData = itemPtr
+
+	utils.Info(fmt.Sprintf("Dequeuer started with %v sleeping time...", sleepDuration))
+
+	for {
+		// TODO: add concurrency settings? like how many max concurrent execution at the same time
+		func() {
+			if err := queueItem.Dequeue(); err != nil {
+				time.Sleep(sleepDuration)
+				return
+			}
+			defer queueItem.CleanUp()
+
+			itemString := fmt.Sprintf("queue `%v` with Identity `%v`",
+				queueItem.ID.Hex(),
+				queueItem.ItemData.Identity(),
+			)
+			utils.Info(fmt.Sprintf("[Amagi-Queue] Starting process for %s", itemString))
+			procStart := time.Now()
+			if err := queueItem.ItemData.Execute(); err != nil {
+				utils.Error(fmt.Sprintf("[Amagi-Queue] error queueItem.Execute for %s: %v", itemString, err))
+				defer queueItem.Fail()
+				return
+			}
+			queueItem.Success()
+			utils.Info(fmt.Sprintf("[Amagi-Queue] Queued %s is done, took: %v",
+				itemString,
+				time.Since(procStart),
+			))
+		}()
+	}
+}
+
+func getSleepDuration() time.Duration {
+	if durationEnv := os.Getenv(DequeuerSleepDurationEnv); durationEnv != "" {
+		duration, err := strconv.Atoi(durationEnv)
+		if err != nil {
+			utils.Error(fmt.Sprintf("[Amagi-Queue] Invalid dequeuer sleep duration value: %v", err))
+			utils.Warn(fmt.Sprintf("[Amagi-Queue] Using default sleep duration: %v", defaultSleepDuration))
+			return defaultSleepDuration
+		}
+		return (time.Duration(duration) * time.Millisecond)
+	}
+	return defaultSleepDuration
+}

--- a/services/queue/dequeuer.go
+++ b/services/queue/dequeuer.go
@@ -23,7 +23,7 @@ func Dequeue(itemPtr Executor) {
 	queueItem := Queue{}
 	queueItem.ItemData = itemPtr
 
-	utils.Info(fmt.Sprintf("Dequeuer started with %v sleeping time...", sleepDuration))
+	utils.Info(fmt.Sprintf("[Amagi-Queue] Dequeuer started with %v sleeping time...", sleepDuration))
 
 	for {
 		// TODO: add concurrency settings? like how many max concurrent execution at the same time

--- a/services/queue/dequeuer.go
+++ b/services/queue/dequeuer.go
@@ -25,7 +25,8 @@ const (
 //
 //     go Dequeue(A{}, B{}, C{})
 //
-func Dequeue(types ...interface{}) {
+func Dequeue(queueCollectionName string, types ...interface{}) {
+	QueueCollection = queueCollectionName
 	for _, qtype := range types {
 		go startDequeuefunc(qtype)
 	}

--- a/services/queue/queue.go
+++ b/services/queue/queue.go
@@ -1,7 +1,230 @@
 package queue
 
-// StartTaskQueue start queue or for task looping
-func StartTaskQueue() error {
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	utils "github.com/b-eee/amagi"
+	"github.com/b-eee/amagi/services/database"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type (
+	// Executor queue execute command
+	Executor interface {
+		// Execute the method to call during dequeueing
+		Execute() error
+		// Identity must be an identifying string for the item
+		Identity() string
+	}
+
+	// Statuses import queue statuses
+	Statuses int
+
+	// Queue object of a queue item
+	Queue struct {
+		ID         bson.ObjectId `bson:"_id"`
+		Status     Statuses      `bson:"status"`
+		CreatedAt  time.Time     `bson:"created_at"`
+		StartedAt  time.Time     `bson:"started_at"`
+		FinishedAt time.Time     `bson:"finished_at"`
+		ItemData   Executor      `bson:"item_data"`
+		ItemType   string        `bson:"item_type"`
+
+		notFilterQueueNameDequeue bool
+	}
+)
+
+const (
+	// StatusQueued the item is registered to queue
+	StatusQueued Statuses = iota
+	// StatusProgress the queue item is currently being run
+	StatusProgress
+	// StatusDone the item has completed execution
+	StatusDone
+	// StatusError the item encountered an error
+	StatusError
+)
+
+var (
+	// QueueCollection collection name
+	QueueCollection = "queue_import"
+)
+
+// SetBSON implements bson.Setter. This is needed because mgo does cannot map bson values to interfaces with methods
+func (item *Queue) SetBSON(raw bson.Raw) error {
+
+	decoded := new(struct {
+		ID         bson.ObjectId `bson:"_id"`
+		Status     Statuses      `bson:"status"`
+		CreatedAt  time.Time     `bson:"created_at"`
+		StartedAt  time.Time     `bson:"started_at"`
+		FinishedAt time.Time     `bson:"finished_at"`
+		ItemData   interface{}   `bson:"item_data"`
+		ItemType   string        `bson:"item_type"`
+	})
+
+	bsonErr := raw.Unmarshal(decoded)
+	if bsonErr == nil {
+		// need to manually assign values here...
+		item.ID = decoded.ID
+		item.Status = decoded.Status
+		item.CreatedAt = decoded.CreatedAt
+		item.StartedAt = decoded.StartedAt
+		item.FinishedAt = decoded.FinishedAt
+		item.ItemType = decoded.ItemType
+	} else {
+		return bsonErr
+	}
+	// after setting everything else, get the interface data and assign it to the initialized one in `item`
+	// marshal the bson data, then unmarshal it again into the `item.ItemData`
+	bsonBytes, _ := bson.Marshal(decoded.ItemData)
+	if bsonErr = bson.Unmarshal(bsonBytes, item.ItemData); bsonErr != nil {
+		return bsonErr
+	}
+	return nil
+}
+
+// Enqueue adds the item to queue db
+//
+// For example:
+//
+//     go models.Queue{ItemData: d}.Enqueue()
+//
+func (item Queue) Enqueue() error {
+	if item.ItemData == nil {
+		return fmt.Errorf("Queue item must have ItemData: %v", item)
+	}
+	sc := database.SessionCopy()
+	defer sc.Close()
+	coll := sc.DB(database.Db).C(QueueCollection)
+
+	item.ID = bson.NewObjectId()
+	item.Status = StatusQueued
+	item.CreatedAt = time.Now()
+	item.ItemType = item.ExecName()
+
+	if err := coll.Insert(item); err != nil {
+		utils.Error(fmt.Sprintf("[Amagi-Queue] error Enqueue: %v", err))
+		return err
+	}
+	return nil
+}
+
+// Dequeue finds an item and claims it for processing
+//
+// For example:
+//
+//     var queueItem Queue
+//     if err := queueItem.Dequeue(); err != nil {}
+//     fmt.Print(queueItem.Status)
+//
+func (item *Queue) Dequeue() error {
+	if item.ItemData == nil {
+		return fmt.Errorf("Queue item must have ItemData not set to nil")
+	}
+	sc := database.SessionCopy()
+	defer sc.Close()
+	coll := sc.DB(database.Db).C(QueueCollection)
+
+	change := mgo.Change{
+		Update: bson.M{"$set": bson.M{
+			"status":     StatusProgress,
+			"started_at": time.Now(),
+		}},
+		ReturnNew: true,
+	}
+	// var dequeued *deququed
+	selector := bson.M{"status": StatusQueued}
+	if !item.notFilterQueueNameDequeue {
+		selector["item_type"] = item.ExecName()
+	}
+
+	if _, err := coll.Find(selector).Sort("created_at").Apply(change, item); err != nil {
+		if err != mgo.ErrNotFound {
+			// Do not print error message if none found
+			utils.Error(fmt.Sprintf("[Amagi-Queue] error Dequeue: %v", err))
+		}
+		return err
+	}
 
 	return nil
+}
+
+// FilterDequeue set to filter or not queueName during dequeue
+// setting this this false may cause `panic`s on runtime, be careful!!!
+func (item *Queue) FilterDequeue(filter bool) {
+	item.notFilterQueueNameDequeue = !filter
+}
+
+// Success sets Queue.Status = StatusDone
+func (item *Queue) Success() error {
+	if err := item.updateQueue(StatusDone); err != nil {
+		utils.Error(fmt.Sprintf("[Amagi-Queue] error ImportSuccess %v", err))
+		return err
+	}
+	return nil
+}
+
+// Fail sets Queue.Status = StatusError
+func (item *Queue) Fail() error {
+	if err := item.updateQueue(StatusError); err != nil {
+		utils.Error(fmt.Sprintf("[Amagi-Queue] error ImportFail %v", err))
+		return err
+	}
+	return nil
+}
+
+// ExecName get the calculated name of the Executor dataItem
+func (item *Queue) ExecName() string {
+	if item.ItemData == nil {
+		return ""
+	}
+	l := strings.Split(reflect.TypeOf(item.ItemData).String(), ".")
+	if len(l) <= 0 {
+		return ""
+	}
+	n := l[len(l)-1]
+	return n
+}
+
+// CleanUp sets the item to nil
+func (item *Queue) CleanUp() {
+	item.ID = ""
+	item.Status = 0
+	item.CreatedAt = time.Time{}
+	item.StartedAt = time.Time{}
+	item.FinishedAt = time.Time{}
+	item.ItemType = ""
+	p := reflect.ValueOf(item.ItemData).Elem()
+	p.Set(reflect.Zero(p.Type()))
+	utils.Info(fmt.Sprintf("[Amagi-Queue] Item cleaned-up: %v", item))
+}
+
+func (item *Queue) updateQueue(status Statuses) error {
+
+	sc := database.SessionCopy()
+	defer sc.Close()
+	coll := sc.DB(database.Db).C(QueueCollection)
+
+	query := bson.M{"_id": item.ID}
+	update := bson.M{"$set": bson.M{
+		"status":      status,
+		"finished_at": time.Now(),
+	}}
+	if err := coll.Update(query, update); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (status Statuses) String() string {
+	return []string{
+		"StatusQueued",
+		"StatusProgress",
+		"StatusDone",
+	}[status]
 }

--- a/services/queue/queue.go
+++ b/services/queue/queue.go
@@ -175,7 +175,9 @@ func GetTypeName(t interface{}) string {
 
 // CleanUp sets the item to nil
 func (item *Queue) CleanUp() {
+	notFilterQueueNameDequeue := item.notFilterQueueNameDequeue
 	item = &Queue{}
+	item.notFilterQueueNameDequeue = notFilterQueueNameDequeue
 	utils.Info(fmt.Sprintf("[Amagi-Queue] Item cleaned-up: %v", item))
 }
 

--- a/services/queue/queue.go
+++ b/services/queue/queue.go
@@ -54,7 +54,7 @@ const (
 
 var (
 	// QueueCollection collection name
-	QueueCollection = "queue_import"
+	QueueCollection = "queue_items"
 )
 
 // Enqueue adds the item to queue db


### PR DESCRIPTION
This queue system is persitent to mongodb. It assumes that the app is using amagi's mongodb service for this to work. 
Also, the queue item must implement this interface:

```go
type Executor interface {
	// Execute the method to call during dequeueing
	Execute() error
	// Identity must be an identifying string for the item
	Identity() string
}
```

This feature uses `encoding/gob` to serialize items for robust storage to any kind of storage, including mongodb.

--- 

Example:

You need to start the `Dequeue` process with the intended collection name and item types (as values) before you can add items to the queue.
```go
import (
	"fmt"

	"github.com/b-eee/amagi/services/queue"
)

type User struct {
	Username, First, Last string
}

func (user User) Execute() error {
	fmt.Println("Hello", user.First, user.Last)
}

func (user User) Identity() string {
	return user.Username
}

func main() {
	// to change the collection name just change the queue.QueueCollection with the collection name as string
	// queue.QueueCollection == "queue_items"
	queue.Dequeue(queue.QueueCollection,
		models.DatastoreImport{},
	)

	user1 := &User{"johndoe", "John", "Doe"}
	item := queue.Queue{ItemExec: &user1}
	if err := item.Enqueue(); err != nil {
		panic(fmt.Errorf("Error adding to queue: %v", err))
	}
}
```