### PR TITLE
fix2999

### DIFF
--- a/services/database/mongodb.go
+++ b/services/database/mongodb.go
@@ -193,11 +193,11 @@ func SessionCopy() *mongodb.Session {
 	sc := MongodbSession.Copy()
 
 	// setMode ref: https://godoc.org/labix.org/v2/mgo#Session.SetMode
-	sc.SetMode(mongodb.PrimaryPreferred, true)
+	// sc.SetMode(mongodb.PrimaryPreferred, true)
 
 	// https://godoc.org/labix.org/v2/mgo#Session.SetSafe
 	// W: 2  atleast two instances confirm of writes
-	sc.SetSafe(&mongodb.Safe{WMode: "majority", W: ensureMaxWrite, FSync: true})
+	// sc.SetSafe(&mongodb.Safe{WMode: "majority", W: ensureMaxWrite, FSync: true})
 	sc.SetSyncTimeout(maxSyncTimeout * time.Second)
 	sc.SetSocketTimeout(maxSyncTimeout * time.Hour)
 	return sc


### PR DESCRIPTION
https://zube.io/b-eee/hexalink/c/2999

https://stackoverflow.com/questions/30367537/mongodb-inserts-slow-down-when-in-replica-set-mode